### PR TITLE
Allow Contao default colors when using local/dev/staging env_title

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,11 +44,11 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('env_color')
                     ->info('Configures the color of the environment badge.')
-                    ->defaultValue('')
+                    ->defaultValue(null)
                 ->end()
                 ->scalarNode('main_color')
                     ->info('Configures the background color of the main container.')
-                    ->defaultValue('')
+                    ->defaultValue(null)
                 ->end()
             ->end()
         ;

--- a/src/ParameterBag/BackendParameterBag.php
+++ b/src/ParameterBag/BackendParameterBag.php
@@ -100,7 +100,7 @@ class BackendParameterBag
 
     public function getEnvColor(): string
     {
-        if (!empty($this->envColor)) {
+        if (null !== $this->envColor) {
             return $this->envColor;
         }
 
@@ -125,7 +125,7 @@ class BackendParameterBag
 
     public function getMainColor(): string
     {
-        if (!empty($this->mainColor)) {
+        if (null !== $this->mainColor) {
             return $this->mainColor;
         }
 


### PR DESCRIPTION
Currently there is no way to keep Contao's default colors for `#main` and login if you use `local`, `dev` or `staging` for the `env_title`. This is problematic, because even if you would reset `main_color` to `#eaeaec`, the login page would then contain that background color as well, which will look wrong.

This PR changes the default values for `env_color` and `main_color` to `null` and replaces the `empty()` check with a `null` check. This way the default behavior is still the same as before, but now you can define `main_color: ''` in order to keep the default colors of the Contao back end theme.